### PR TITLE
Show traditional characters on translation page

### DIFF
--- a/lib/Teochew.pm
+++ b/lib/Teochew.pm
@@ -1667,6 +1667,32 @@ sub get_approx_num_translations {
     return $word_count + $sentence_count;
 }
 
+=head2 get_traditional
+
+Given a string with simplified Chinese characters, this checks to see if the
+traditional variant is different, and if it is, it will return that. This
+returns nothing if they are the same
+
+=cut
+
+sub get_traditional {
+    my $full_simplified = shift;
+    my @simplified = split //, $full_simplified;
+
+    my $full_traditional = '';
+
+    for my $i (0..$#simplified) {
+        my $traditional = $dbh->selectrow_array(qq{
+            select traditional from Chinese
+            where simplified = ?
+        }, undef, $simplified[$i]);
+
+        $full_traditional .= ($traditional || $simplified[$i]);
+    }
+
+    return $full_traditional if $full_traditional ne $full_simplified;
+}
+
 # TODO
 #sub find_phrases_using_word {
 #}

--- a/lib/Teochew/Utils.pm
+++ b/lib/Teochew/Utils.pm
@@ -166,9 +166,17 @@ sub link_teochew_words {
     }
 
     my $pengim  = join ' ', @pengim_parts;
-    my $chinese = join '', map { $_->{chinese} } @components;
+    my $simplified  = join '', map { $_->{simplified} } @components;
+    my $traditional = join '', map { $_->{traditional} || $_->{simplified} }
+                               @components;
 
-    return { pengim => $pengim, chinese => $chinese };
+    my $return = {
+        pengim      => $pengim,
+        simplified  => $simplified,
+    };
+    $return->{traditional} = $traditional if $simplified ne $traditional;
+
+    return $return;
 }
 
 =head2 split_out_parens

--- a/sql/setup_teochew.sql
+++ b/sql/setup_teochew.sql
@@ -1101,7 +1101,7 @@ INSERT INTO Chinese VALUES(382,'橱','櫥','du5',NULL);
 INSERT INTO Chinese VALUES(383,'枕',NULL,'jim2',NULL);
 INSERT INTO Chinese VALUES(384,'厕','廁','che3',NULL);
 INSERT INTO Chinese VALUES(385,'所',NULL,'so2',NULL);
-INSERT INTO Chinese VALUES(386,'床','牀','cheung5',NULL);
+INSERT INTO Chinese VALUES(386,'床',NULL,'cheung5',NULL);
 INSERT INTO Chinese VALUES(387,'灇',NULL,'jang5',NULL);
 INSERT INTO Chinese VALUES(388,'洗',NULL,'soi2',NULL);
 INSERT INTO Chinese VALUES(389,'窗',NULL,'teng1',NULL);
@@ -1169,7 +1169,7 @@ INSERT INTO Chinese VALUES(450,'滴',NULL,'dih4',NULL);
 INSERT INTO Chinese VALUES(451,'屑',NULL,'suk4',NULL);
 INSERT INTO Chinese VALUES(452,'布',NULL,'bou3',NULL);
 INSERT INTO Chinese VALUES(453,'输','輸','su1',NULL);
-INSERT INTO Chinese VALUES(454,'表','錶','bio1',NULL);
+INSERT INTO Chinese VALUES(454,'錶',NULL,'bio1',NULL);
 INSERT INTO Chinese VALUES(455,'索',NULL,'soh4',NULL);
 INSERT INTO Chinese VALUES(456,'裙',NULL,'gung5',NULL);
 INSERT INTO Chinese VALUES(457,'松',NULL,'song5',NULL);
@@ -1627,6 +1627,8 @@ INSERT INTO TeochewAltChinese VALUES(26,743,'澹');
 INSERT INTO TeochewAltChinese VALUES(27,748,'若');
 INSERT INTO TeochewAltChinese VALUES(28,772,'差毋多');
 INSERT INTO TeochewAltChinese VALUES(29,777,'抠');
+INSERT INTO TeochewAltChinese VALUES(30,159,'牀');
+INSERT INTO TeochewAltChinese VALUES(31,535,'手表');
 CREATE TABLE Translation (
     id integer primary key,
     english_id integer references English(id),
@@ -2909,7 +2911,7 @@ INSERT INTO Teochew VALUES(531,'da1','灱');
 INSERT INTO Teochew VALUES(532,'jui26 bou3','水布');
 INSERT INTO Teochew VALUES(533,'meng7 bou3','面布');
 INSERT INTO Teochew VALUES(534,'su1','输');
-INSERT INTO Teochew VALUES(535,'chiu26 bio1','手表');
+INSERT INTO Teochew VALUES(535,'chiu26 bio1','手錶');
 INSERT INTO Teochew VALUES(536,'chiu26 soh4','手索');
 INSERT INTO Teochew VALUES(537,'chiu26 ji2','手只');
 INSERT INTO Teochew VALUES(538,'gung5','裙');

--- a/templates/elements/all-translations-table.html.ep
+++ b/templates/elements/all-translations-table.html.ep
@@ -45,7 +45,9 @@
           <td class="pengim">
             <%= $inner_row->{pronunciations}[0]{pengim} %>
           </td>
-          <td><%= $inner_row->{chinese} %></td>
+          <td>
+            %= $inner_row->{chinese}{simplified}
+          </td>
           <td>
             % if ($inner_row->{pronunciations}[0]{audio}) {
               <%= include 'elements/play-teochew',

--- a/templates/elements/translation-row.html.ep
+++ b/templates/elements/translation-row.html.ep
@@ -15,7 +15,11 @@
 % }
 <td><%= $word %></td>
 <td><%= $translation->{pronunciations}[0]{pengim} %></td>
-<td><%= $translation->{chinese} %></td>
+<td>
+  <span style="white-space:nowrap">
+    <%= $translation->{chinese}{simplified} %>
+  </span>
+</td>
 <td>
   % if ($translation->{pronunciations}[0]{audio}) {
   <%= include 'elements/play-teochew',

--- a/templates/elements/translation.html.ep
+++ b/templates/elements/translation.html.ep
@@ -3,7 +3,7 @@
 % my $style = stash('hidden') ? 'style="display:none"' : '';
 % my $id = stash('id') ? 'id="' . stash('id') . '"' : '';
 <div class="translation" <%== $id %> <%== $style %>>
-  <span class="chinese nowrap mr-2 align-middle"><%= $row->{chinese} %></span>
+  <span class="chinese nowrap mr-2 align-middle"><%= $row->{chinese}{simplified} %></span>
   % my $pronunciation = $row->{pronunciations}[0];
   <span class="pengim nowrap mr-2 align-middle">
     <%= $pronunciation->{pengim} %>

--- a/templates/flashcard.html.ep
+++ b/templates/flashcard.html.ep
@@ -142,7 +142,7 @@
             elt.attr('id', '');
 
             elt.find('.pengim').html(translation.pronunciations[0].pengim);
-            elt.find('.chinese').html(translation.chinese);
+            elt.find('.chinese').html(translation.chinese.simplified);
             if (translation.pronunciations[0].audio) {
                 var play_elt = `<%= include 'elements/play-teochew' =%>`;
                 var audio = $(play_elt.trim());

--- a/templates/lessons/tones.html.ep
+++ b/templates/lessons/tones.html.ep
@@ -9,7 +9,7 @@
 There are 8 tones in Teochew. In many resources, you will see a number after
 each syllable, indicating which tone it is.
 </p>
-<div class="row"><div class="col-md-6 offset-md-3">
+<div class="row"><div class="col-md-8 offset-md-2">
 <table class="table table-sm">
   <thead>
     <tr>
@@ -78,7 +78,7 @@ Many words undergo tone change when placed in front of another word. This is
 called <b>sandhi</b>. The table below shows the same words as above, but placed
 in front of another word to demonstrate how their tones change.
 </p>
-<div class="row"><div class="col-md-6 offset-md-3">
+<div class="row"><div class="col-md-8 offset-md-2">
 <table class="table table-sm">
   <thead>
     <th>Original Tone</th>

--- a/templates/translate.html.ep
+++ b/templates/translate.html.ep
@@ -42,7 +42,7 @@
           %= include 'elements/translation', row => $row
 
 
-          % if ($row->{compound} || $row->{extra_notes} || $row->{pronunciations}[1] || $row->{alt_chinese}) {
+          % if ($row->{compound} || $row->{extra_notes} || $row->{pronunciations}[1] || $row->{alt_chinese} || $row->{chinese}{traditional}) {
             <a data-toggle="collapse" href="#word-breakdown-<%= $row_id %>">
               <small>
                 More details <i class="ion-arrow-down-b"></i>
@@ -54,12 +54,18 @@
             <div id="word-breakdown-<%= $row_id %>"
                  class="word-breakdown collapse my-2">
 
+            % if (my $traditional = $row->{chinese}{traditional}) {
+                <div class="traditional">
+                  Traditional: <%= $traditional %>
+                </div>
+            % }
+
             %# If there is a standard "Teochew proper" pronunciation that is
             %# different than the Gekion one that I use by default, display
             %# that here
             % if (my $standard_pronunciation = $row->{pronunciations}[1]) {
               <div class="teochew-proper-pronunciation">
-              潮州音: <%= $standard_pronunciation->{pengim} %>
+              潮州: <%= $standard_pronunciation->{pengim} %>
               % if ($standard_pronunciation->{audio}) {
                 <%= include 'elements/play-teochew',
                       audio => $standard_pronunciation->{audio} %>


### PR DESCRIPTION
If it differs from the simplified version. I thought about adding this to the translation tables as well, but it looks really cluttered that way. Eventually I'd like to add an option to show traditional by default, but this is just a start towards that.